### PR TITLE
dropping inboundBearing from reference id per #5

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -103,9 +103,6 @@ export function referenceMessage (locationReferences: LocationReference[], formO
       message += ` ${Math.floor(lr.outboundBearing)}`
       message += ` ${Math.floor(lr.distanceToNextRef * 100)}` // store in centimeter
     }
-    if (lr.inboundBearing !== null && lr.inboundBearing !== undefined) {
-      message += ` ${round(lr.inboundBearing, 1)}`
-    }
   })
   return message
 }


### PR DESCRIPTION
Dropping inboundBearing from reference id gen per #5 

This isn't part of OpenLR and not sure we need it to be in the ref id hash. 