### PR TITLE
Define formOfWay as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Reference Id
 **Parameters**
 
 -   `locationReferences` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;LocationReference>** An Array of Location References.
--   `formOfWay` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Form Of Way
+-   `formOfWay` **([string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) \| [number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number))** Form Of Way (optional, default `0`)
 
 **Examples**
 
@@ -113,7 +113,7 @@ const locationReferences = [
 const formOfWay = 2; // => "MultipleCarriageway"
 
 const id = sharedstreets.referenceId(locationReferences, formOfWay);
-id // => "???"
+id // => "ef209661aeebadfb4e0a2cb93153493f"
 ```
 
 Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** SharedStreets Reference Id

--- a/index.ts
+++ b/index.ts
@@ -75,8 +75,8 @@ export function intersectionMessage(pt: number[] | Feature<Point> | Point): stri
 /**
  * Reference Id
  *
- * @param {string} formOfWay Form Of Way
  * @param {Array<LocationReference>} locationReferences An Array of Location References.
+ * @param {string|number} [formOfWay=0] Form Of Way
  * @returns {string} SharedStreets Reference Id
  * @example
  * const locationReferences = [
@@ -86,9 +86,9 @@ export function intersectionMessage(pt: number[] | Feature<Point> | Point): stri
  * const formOfWay = 2; // => "MultipleCarriageway"
  *
  * const id = sharedstreets.referenceId(locationReferences, formOfWay);
- * id // => "???"
+ * id // => "ef209661aeebadfb4e0a2cb93153493f"
  */
-export function referenceId(locationReferences: LocationReference[], formOfWay: FormOfWay): string {
+export function referenceId(locationReferences: LocationReference[], formOfWay: FormOfWay = 0): string {
   const message = referenceMessage(locationReferences, formOfWay);
   return generateHash(message);
 }
@@ -98,7 +98,7 @@ export function referenceId(locationReferences: LocationReference[], formOfWay: 
  *
  * @private
  */
-export function referenceMessage(locationReferences: LocationReference[], formOfWay: string | number): string {
+export function referenceMessage(locationReferences: LocationReference[], formOfWay: string | number = 0): string {
   // Convert FormOfWay to Number if encoding ID
   if (typeof formOfWay !== "number") { formOfWay = getFormOfWayNumber(formOfWay); }
 


### PR DESCRIPTION
For a basic implementation of a ReferenceMessage `formOfWay` should be defined as "Other" (0) by default instead of a required param.