### PR TITLE
Add geometry method to core js library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 2018-02-08 - 0.6.0
+## 2018-02-11 - 0.7.0
 
 - Convert tests to Typescript
+- Add new method `geometry`
+
+## 2018-02-08 - 0.6.0
+
 - Make `formOfWay` optional for `referenceId` method.
 - Add `coordsToLonlats` method
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ $ yarn test
 #### Table of Contents
 
 -   [geometryId](#geometryid)
+-   [geometry](#geometry)
 -   [intersectionId](#intersectionid)
 -   [referenceId](#referenceid)
 -   [lonlatsToCoords](#lonlatstocoords)
@@ -71,6 +72,28 @@ id // => "ce9c0ec1472c0a8bab3190ab075e9b21"
 ```
 
 Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** SharedStreets Geometry Id
+
+### geometry
+
+geometry
+
+**Parameters**
+
+-   `line` **(Feature&lt;LineString> | [Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)>>)** GeoJSON LineString Feature
+-   `options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Optional parameters (optional, default `{}`)
+    -   `options.formOfWay` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Property field that contains FormOfWay value (number/string).
+    -   `options.roadClass` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** Property field that contains RoadClass value (number/string).
+
+**Examples**
+
+```javascript
+const line = [[110, 45], [115, 50], [120, 55]];
+const geom = sharedstreets.geometry(line);
+geom.id; // => "ce9c0ec1472c0a8bab3190ab075e9b21"
+geom.lonlats; // => [ 110, 45, 115, 50, 120, 55 ]
+```
+
+Returns **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;SharedStreetsGeometry>** SharedStreets Geometries
 
 ### intersectionId
 

--- a/package.json
+++ b/package.json
@@ -45,8 +45,11 @@
     "typescript": "*"
   },
   "dependencies": {
+    "@turf/bearing": "*",
+    "@turf/distance": "*",
     "@turf/helpers": "6.x",
     "@turf/invariant": "6.x",
+    "@turf/line-offset": "*",
     "bignumber.js": "6.x",
     "sharedstreets-types": "1.x"
   }

--- a/test.ts
+++ b/test.ts
@@ -156,3 +156,18 @@ test("sharedstreets -- coordsToLonlats", (t) => {
   t.deepEqual(lonlats, [110, 45, 120, 55]);
   t.end();
 });
+
+test("sharedstreets -- geometry", (t) => {
+  const line = [[110, 45], [115, 50], [120, 55]];
+  const geom = sharedstreets.geometry(line);
+  t.deepEqual(geom, {
+    backReferenceId: "197cb60a06518f4d616fea25b5e81266",
+    forwardReferenceId: "79aad7fa7e4fec23ff2c97d0b33086ce",
+    fromIntersectionId: "71f34691f182a467137b3d37265cb3b6",
+    id: "ce9c0ec1472c0a8bab3190ab075e9b21",
+    lonlats: [ 110, 45, 115, 50, 120, 55 ],
+    roadClass: "Other",
+    toIntersectionId: "42286ee839cf23904b00acfc7d13a2e2",
+  });
+  t.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,15 +45,53 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
+"@turf/bearing@*":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-5.1.5.tgz#7a0b790136c4ef4797f0246305d45cbe2d27b3f7"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+
+"@turf/distance@*":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-5.1.5.tgz#39cf18204bbf87587d707e609a60118909156409"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+
 "@turf/helpers@6.x":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.0.1.tgz#625112616159e519033dc5d24c094ccbce7a457f"
+
+"@turf/helpers@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
 
 "@turf/invariant@6.x":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.0.1.tgz#45581b41f82d91b682cef427e897c840d1741757"
   dependencies:
     "@turf/helpers" "6.x"
+
+"@turf/invariant@^5.1.5":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+
+"@turf/line-offset@*":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/line-offset/-/line-offset-5.1.5.tgz#2ab5b2f089f8c913e231d994378e79dca90b5a1e"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+
+"@turf/meta@^5.1.5":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-5.2.0.tgz#3b1ad485ee0c3b0b1775132a32c384d53e4ba53d"
+  dependencies:
+    "@turf/helpers" "^5.1.5"
 
 "@types/events@*":
   version "1.1.0"


### PR DESCRIPTION
## Add geometry method to core js library

Pulled from [`sharedstreets-conflator`](https://github.com/sharedstreets/sharedstreets-conflator), core methods such as `geometry` & others core methods should be included in the main `sharedstreets-js` library.

**js example**
```js
const line = [[110, 45], [115, 50], [120, 55]];
const geom = sharedstreets.geometry(line);
geom.id; // => "ce9c0ec1472c0a8bab3190ab075e9b21"
geom.lonlats; // => [ 110, 45, 115, 50, 120, 55 ]
```

**output**

```js
{
    backReferenceId: "197cb60a06518f4d616fea25b5e81266",
    forwardReferenceId: "79aad7fa7e4fec23ff2c97d0b33086ce",
    fromIntersectionId: "71f34691f182a467137b3d37265cb3b6",
    id: "ce9c0ec1472c0a8bab3190ab075e9b21",
    lonlats: [ 110, 45, 115, 50, 120, 55 ],
    roadClass: "Other",
    toIntersectionId: "42286ee839cf23904b00acfc7d13a2e2",
  }
```
