### PR TITLE
Provide Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:11
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+USER node
+WORKDIR /home/node/
+
+COPY *.json ./
+
+RUN npm install --only=dev && \
+  npm install --only=prod 
+
+COPY src/ ./src/
+COPY bin/ ./bin/
+RUN npm pack
+
+FROM node:11 
+
+ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
+ENV PATH=$PATH:/home/node/.npm-global/bin
+
+WORKDIR /home/node/
+USER node
+COPY --from=0 /home/node/*.tgz .
+
+RUN npm install -g *.tgz
+
+ENTRYPOINT ["shst"]
+CMD ["--help"]

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "leveldown": "^5.0.0",
     "levelup": "^4.0.1",
     "node-fetch": "^2.3.0",
-    "osrm": "^5.22.0",
+    "osrm": "5.22.0",
     "rbush": "^3.0.0",
     "sharedstreets-pbf": "^0.8.0",
     "sharedstreets-types": "^1.3.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
+    "rootDir": ".",                           /* To keep src directory structure TSC3 requires rootDir to be set */
     "outDir": "build/",
     "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */


### PR DESCRIPTION
Though there is an older upstream/docker branch, this apparently didn't make it into master.
That's why I start a second attempt providing a multi-staged build directly from the sources.

I tried to build the current master branch but had some issues: Typescript3 seems to require a rootDir to reproduce the same directory structure that oclif config expects to find the commands, and osrm 5.23.0 apparently is not downloadable from mapbox, so I clamped it's version to 5.22.0.


 