### PR TITLE
Fix issue where Graph could not be created with empty extent

### DIFF
--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -39,14 +39,18 @@ export async function getTilesForId(id:string) {
 
 export function getTileIdsForPolygon(polygon:turfHelpers.Feature<turfHelpers.Polygon>, buffer:number=0):string[] {
 
-    var polyBound = bbox(polygon)
+    if (polygon === null) {
+        return [];
+    } else {
 
-    var nwPoint = destination([polyBound[0],polyBound[1]], buffer, 315, {'units':'meters'});
-    var sePoint = destination([polyBound[2],polyBound[3]], buffer, 135, {'units':'meters'});
-    let bounds = [nwPoint.geometry.coordinates[0], nwPoint.geometry.coordinates[1], sePoint.geometry.coordinates[0], sePoint.geometry.coordinates[1]];
-    
-    return getTileIdsForBounds(bounds, false);
-  
+        var polyBound = bbox(polygon)
+
+        var nwPoint = destination([polyBound[0],polyBound[1]], buffer, 315, {'units':'meters'});
+        var sePoint = destination([polyBound[2],polyBound[3]], buffer, 135, {'units':'meters'});
+        let bounds = [nwPoint.geometry.coordinates[0], nwPoint.geometry.coordinates[1], sePoint.geometry.coordinates[0], sePoint.geometry.coordinates[1]];
+        
+        return getTileIdsForBounds(bounds, false);
+    }
 }
 
 export function getTileIdsForPoint(point:turfHelpers.Feature<turfHelpers.Point>, buffer:number):string[] {


### PR DESCRIPTION
This small change fixes an issue where a Graph could not be created with an empty extent. The bug has been mentioned here (#92) and here (#90), and I was experiencing it myself when using the `match` command.

It looks like a check was added for an empty extent at some point with this commit: [fix error handling for empty tiles](https://github.com/sharedstreets/sharedstreets-js/commit/f28cbe27642a849a3927eb190b3d6cc699b3947e) but the null check need to be moved to a point before any turf packages were invoked. It is possible that turf had null checks in their methods at some point in the past but has removed them, causing the issue described.

I tested this with the tests included and with my own data, and the Graph should now be able to be created with an empty extent.
